### PR TITLE
let circle create snapshot binary artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,9 @@ dependencies:
     - make deps
   override:
     - make build
+  post:
+    - tar -czvf $CIRCLE_ARTIFACTS/gun-linux.tgz -C build/Linux gun
+    - tar -czvf $CIRCLE_ARTIFACTS/gun-darwin.tgz -C build/Darwin gun
 
 test:
   override:


### PR DESCRIPTION
Circleci's artifact feature comes handy, when you want to provide dev/snapshot builds from master:
- gun-darwin.tgz
- gun-linux.tgz
