### PR TITLE
Fixing os arch separator for glidergun-rack tagging

### DIFF
--- a/include/deps.bash
+++ b/include/deps.bash
@@ -27,7 +27,7 @@ deps-install() {
 	local tag index tmpdir tmpfile dep filename extension install
 	mkdir -p "$(deps-dir)/bin"
 	index=$(curl -s "$DEPS_REPO/$name")
-	tag="$(uname -s)$(uname -m | grep -s 64 > /dev/null && echo amd64 || echo 386)"
+	tag="$(uname -s)_$(uname -m | grep -s 64 > /dev/null && echo amd64 || echo 386)"
 	if ! dep="$(echo "$index" | grep -i -e "^$version $tag " -e "^$version * ")"; then
 		echo "!! Dependency not in index: $name $version" | red
 		exit 2


### PR DESCRIPTION
glidergun-rack uses `OS_ARCH` as tags rather than `OSARCH`

for example:

```
latest linux_amd64 http://stedolan.github.io/jq/download/linux64/jq 89c7bb6138fa6a5c989aca6b71586acc
latest darwin_amd64 http://stedolan.github.io/jq/download/osx64/jq 086ddfa932021e98bf967aff74badafe
```
