### PR TITLE
Match only with os_arch including in the tag filter

### DIFF
--- a/include/deps.bash
+++ b/include/deps.bash
@@ -28,7 +28,7 @@ deps-install() {
 	mkdir -p "$(deps-dir)/bin"
 	index=$(curl -s "$DEPS_REPO/$name")
 	tag="$(uname -s)$(uname -m | grep -s 64 > /dev/null && echo amd64 || echo 386)"
-	if ! dep="$(echo "$index" | grep -i -e "^$version $tag " -e "^$version * ")"; then
+	if ! dep="$(echo "$index" | grep -i "^$version $tag " || echo "$index" | grep -i "^$version * ")"; then
 		echo "!! Dependency not in index: $name $version" | red
 		exit 2
 	fi


### PR DESCRIPTION
please note the title of the PR is misleading, it should be: Match _first_ with os_arch including 

when testing glidergun 0.0.5 on a mac, wrong version of the **jq** dependency is downloaded:

```
* Dependency required, installing jq 1.4 ...
cmds/ec2.bash: line 12: /Users/lalyos/prj/glidergun/tests/project/.gun/bin/jq: cannot execute binary file: Exec format error
```

with `TRACE` switch on, it turns out that the grep is too greedy and matching all the versions even when the
os/arch is not matching:

```
echo 'latest linux_amd64 http://stedolan.github.io/jq/download/linux64/jq 89c7bb6138fa6a5c989aca6b71586acc
latest darwin_amd64 http://stedolan.github.io/jq/download/osx64/jq 086ddfa932021e98bf967aff74badafe

1.4 linux_amd64 http://stedolan.github.io/jq/download/linux64/jq 89c7bb6138fa6a5c989aca6b71586acc
1.4 darwin_amd64 http://stedolan.github.io/jq/download/osx64/jq 086ddfa932021e98bf967aff74badafe' | grep -i -e '^1.4 Darwin_amd64 ' -e '^1.4 * '

1.4 linux_amd64 http://stedolan.github.io/jq/download/linux64/jq 89c7bb6138fa6a5c989aca6b71586acc
1.4 darwin_amd64 http://stedolan.github.io/jq/download/osx64/jq 086ddfa932021e98bf967aff74badafe
```

I think the correct precendce should be:
- first try with `VERSION OS_ARCH` filter
- fall back to `VERSION` filter
- error message 
