### PR TITLE
Adds bash-complete command

### DIFF
--- a/include/cmd.bash
+++ b/include/cmd.bash
@@ -8,6 +8,13 @@ cmd-list() {
 	cmd-list-keys "$ns" | sed "s/$ns://"
 }
 
+cmd-bash-complete() {
+    declare desc="Creates a bash autocomplete function"
+
+    local commands=$(cmd-list | xargs)
+    echo complete -W \"$commands\" $SELF
+}
+
 cmd-list-keys() {
 	declare ns="$1"
 	for k in "${!CMDS[@]}"; do


### PR DESCRIPTION
you can expose it directly to the use, when adding to main():
    cmd-export cmd-bash-complete bash-complete

It  will generate :

```
$ gun bash-complete
complete -W "bash-complete help init update version" gun
```

or without exporting it, for example runng it in the glidergun/tests/project dir:

```
$ gun prod fn cmd-bash-complete
complete -W "bar bash-complete env fn foo help init update version" gun
```
