### PR TITLE
Change dir into GUN_ROOT

### DIFF
--- a/include/gun.bash
+++ b/include/gun.bash
@@ -44,8 +44,9 @@ gun-find-root() {
   	done
 	if [[ -f "$path/Gunfile" ]]; then
   		GUN_ROOT="$path"
-  		cd "$GUN_ROOT"
   	fi
+
+    [[ -d "$GUN_ROOT" ]] && cd $GUN_ROOT
 }
 
 main() {


### PR DESCRIPTION
In case GUN_ROOT isn't in the parent chain, but given explicitly by an env var: 

```
GUN_ROOT=/etc/mygunroot gun
```

gun-find-root should `cd` into it.
