### PR TITLE
curl follows redirects

### DIFF
--- a/include/deps.bash
+++ b/include/deps.bash
@@ -36,7 +36,7 @@ deps-install() {
 	tmpdir="$(deps-dir)/tmp"
 	mkdir -p "$tmpdir"
 	tmpfile="${tmpdir:?}/$name"
-	curl -s $url > "$tmpfile"
+	curl -Ls $url > "$tmpfile"
 	if [[ "$checksum" ]]; then
 		if ! [[ "$(cat "$tmpfile" | checksum md5)" = "$checksum" ]]; then
 			echo "!! Dependency checksum failed: $name $version $checksum" | red


### PR DESCRIPTION
Github released repos are using redirects:
For example: 

```
$ curl -sI https://github.com/gliderlabs/glidergun/releases/download/v0.0.7/glidergun_0.0.7_Linux_x86_64.tgz|grep Status                     
Status: 302 Found
```
