### PR TITLE
ensure 0 return code when TRACE enabled

### DIFF
--- a/include/gun.bash
+++ b/include/gun.bash
@@ -46,7 +46,9 @@ gun-find-root() {
   		GUN_ROOT="$path"
   	fi
 
-    [[ -d "$GUN_ROOT" ]] && cd $GUN_ROOT
+    if [[ -d "$GUN_ROOT" ]]; then
+        cd $GUN_ROOT
+    fi
 }
 
 main() {


### PR DESCRIPTION
if TRACE is enable `set -e` makes `|| true` required
fixes PR #16 if combined with TRACE=1
