### PR TITLE
Fix deps-check to accept symlinked binaries

### DIFF
--- a/include/deps.bash
+++ b/include/deps.bash
@@ -19,7 +19,7 @@ deps-require() {
 
 deps-check() {
 	declare name="$1" version="${2:-latest}"
-	[[ -f "$(deps-dir)/bin/$name" ]]
+	[[ -e "$(deps-dir)/bin/$name" ]]
 }
 
 deps-install() {


### PR DESCRIPTION
Some package like the gcloud sdk, installs itself in a dir structure witn bin,lib, ...
Symlinking from .gun/bin/gcloud -> .gun/google-cloud-sdk/bin/gcloud seems the easiest
solution
