### PR TITLE
Fixing dependency extension extraction

### DIFF
--- a/include/deps.bash
+++ b/include/deps.bash
@@ -45,7 +45,7 @@ deps-install() {
 	fi
 	cd "$tmpdir"
 	filename="$(basename "$url")"
-	extension="${filename##*.}"
+	extension="${filename#*.}"
 	case "$extension" in
 		zip) unzip "$tmpfile" > /dev/null;;
 		tgz|tar.gz) tar -zxf "$tmpfile" > /dev/null;;


### PR DESCRIPTION
When filename=some.tar.gz the double # eats up 'some.tar.' and leaves only 'gz'
single # extracts correct 'tar.gz'
