### PR TITLE
switch go build compiler to static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Changed
+- Binary is statically compiled
 
 ## [0.0.7] - 2015-02-20
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@ VERSION=0.0.7
 
 build:
 	go-bindata include
-	mkdir -p build/Linux  && GOOS=linux  go build -ldflags "-X main.Version $(VERSION)" -o build/Linux/$(BINARYNAME)
-	mkdir -p build/Darwin && GOOS=darwin go build -ldflags "-X main.Version $(VERSION)" -o build/Darwin/$(BINARYNAME)
+	mkdir -p build/Linux  && GOOS=linux  CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.Version $(VERSION)" -o build/Linux/$(BINARYNAME)
+	mkdir -p build/Darwin && GOOS=darwin CGO_ENABLED=0 go build -a -installsuffix cgo -ldflags "-X main.Version $(VERSION)" -o build/Darwin/$(BINARYNAME)
 
 install: build
 	install build/$(shell uname -s)/gun /usr/local/bin


### PR DESCRIPTION
release 0.0.7 is dynamic, so can't be used for example on alpine docker.

```
$ docker run --rm -it debian:jessie bash -c 'apt-get update && apt-get install -y curl && curl -L https://github.com/gliderlabs/glidergun/releases/download/v0.0.7/glidergun_0.0.7_Linux_x86_64.tgz | tar -xzv && ldd ./gun'

        linux-vdso.so.1 (0x00007ffc94775000)
        libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f7277fc0000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f7277c17000)
        /lib64/ld-linux-x86-64.so.2 (0x00007f72781dd000)
```

With this PR it makes it static

```
$ docker run --rm -it debian:jessie bash -c 'apt-get update && apt-get install -y curl && curl -L https://circle-artifacts.com/gh/sequenceiq/glidergun/16/artifacts/0/tmp/circle-artifacts.jFiiQPu/gun-linux.tgz | tar -xzv && '

 not a dynamic executable
```
