### PR TITLE
Include os specific bash binary with go-bindata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 release
 bindata.go
+.gun
+.bin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 ### Changed
+- Bash version 4.3.30 is included into gun binary
 
 ## [0.0.7] - 2015-02-20
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,10 @@ ARCH=$(shell uname -m)
 VERSION=0.0.7
 
 build:
-	go-bindata include
+	rm -rf .gun/bin && mkdir -p .gun/bin
+	cp .bin/linux/* .gun/bin/ && go-bindata include .gun/bin
 	mkdir -p build/Linux  && GOOS=linux  go build -ldflags "-X main.Version $(VERSION)" -o build/Linux/$(BINARYNAME)
+	cp .bin/osx/* .gun/bin/ && go-bindata include .gun/bin
 	mkdir -p build/Darwin && GOOS=darwin go build -ldflags "-X main.Version $(VERSION)" -o build/Darwin/$(BINARYNAME)
 
 install: build
@@ -15,6 +17,12 @@ deps:
 	go get -u github.com/jteeuwen/go-bindata/...
 	go get -u github.com/progrium/gh-release/...
 	go get || true
+
+binaries:
+	mkdir -p .bin/linux .bin/osx
+	curl -Lo .bin/linux/bash https://github.com/lalyos/bash-static-upx/releases/download/v4.3.30/bash-linux
+	curl -Lo .bin/osx/bash https://github.com/lalyos/bash-static-upx/releases/download/v4.3.30/bash-osx
+	chmod +x .bin/linux/* .bin/osx/*
 
 release:
 	rm -rf release && mkdir release

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,7 @@
 dependencies:
   pre:
     - rm ~/.gitconfig
-    - make deps
+    - make deps binaries
   override:
     - make build
   post:

--- a/glidergun.go
+++ b/glidergun.go
@@ -100,8 +100,15 @@ func Checksum(args []string) {
 	fmt.Printf("%x\n", h.Sum(nil))
 }
 
+func extractBash() {
+	bashDir := ".gun/bin"
+	RestoreAsset(".", bashDir+"/bash")
+	os.Setenv("PATH", bashDir+":"+os.Getenv("PATH"))
+}
+
 func main() {
 	os.Setenv("GUN_VERSION", Version)
+	extractBash()
 	basher.Application(map[string]func([]string){
 		"checksum":   Checksum,
 		"selfupdate": Selfupdate,


### PR DESCRIPTION
There are issues If bash is not present (alpine) or outdated (vanilla OS X). 

```
$ docker run --rm -it debian:jessie sh -c 'rm -f /bin/bash && apt-get update && apt-get install -y curl && curl -L https://gi
thub.com/gliderlabs/glidergun/releases/download/v0.0.7/glidergun_0.0.7_Linux_x86_64.tgz | tar -xzv && ./gun' 

2015/05/25 15:29:05 fork/exec /bin/bash: no such file or directory
```

With this PR:

```
$ docker run --rm -it debian:jessie sh -c 'rm -f /bin/bash && apt-get update && apt-get install -y curl && curl -L https://circle-artifacts.com/gh/sequenceiq/glidergun/17/artifacts/0/tmp/circle-artifacts.fIvEVo2/gun-linux.tgz  | tar -xzv && ./gun'

Available commands:
  help                     Shows help information for a command
  init                     Initialize a glidergun project directory
  update                   Self-update glidergun to latest version
  version                  Display version of glidergun
```
