### PR TITLE
fix download url

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@
 
 
 ## Install
-
-	$ curl https://dl.gliderlabs.com/gh/glidergun/latest/$(uname -sm|tr \  _).tgz \
+    $ curl -L https://github.com/gliderlabs/glidergun/releases/download/v0.1.0/glidergun_0.1.0_$(uname -sm|tr \  _).tgz \
 		| tar -zxC /usr/local/bin
 
-## Upgrading
+## Tutorial
 
-	$ gun :update
-
+See [example/README.md](example/README.md) for a detailed tutorial.
 <img src="https://ga-beacon.appspot.com/UA-58928488-2/glidergun/readme?pixel" />


### PR DESCRIPTION
remove reference to `:update` command as its also based on dl.gliderlabs.com address:
https://github.com/gliderlabs/glidergun/blob/master/glidergun.go#L23